### PR TITLE
Add voice relay for specific team chat user

### DIFF
--- a/src/discordEvents/directMessage.js
+++ b/src/discordEvents/directMessage.js
@@ -18,6 +18,7 @@
 
 */
 const DiscordVoice = require('../discordTools/discordVoice.js');
+const Translate = require('translate');
 
 module.exports = {
     name: 'messageCreate',
@@ -25,13 +26,23 @@ module.exports = {
         if (message.guild) return;
         if (message.author.bot) return;
 
+        let speakText = message.cleanContent;
+        if (/[\u3400-\u9FBF]/.test(message.cleanContent)) {
+            try {
+                speakText = await Translate(message.cleanContent, 'en');
+            }
+            catch (e) {
+                client.log(client.intlGet(null, 'infoCap'), `Translation failed: ${e.message}`);
+            }
+        }
+
         for (const [guildId, rustplus] of Object.entries(client.rustplusInstances)) {
             if (!rustplus || !rustplus.isOperational) continue;
 
             const instance = client.getInstance(guildId);
             if (instance && instance.blacklist['discordIds'].includes(message.author.id)) continue;
 
-            await DiscordVoice.sendDiscordVoiceMessage(guildId, message.cleanContent);
+            await DiscordVoice.sendDiscordVoiceMessage(guildId, speakText);
         }
 
         client.log(client.intlGet(null, 'infoCap'), client.intlGet(null, 'logDiscordMessage', {

--- a/src/discordEvents/directMessage.js
+++ b/src/discordEvents/directMessage.js
@@ -29,7 +29,7 @@ module.exports = {
         let speakText = message.cleanContent;
         if (/[\u3400-\u9FBF]/.test(message.cleanContent)) {
             try {
-                speakText = await Translate(message.cleanContent, 'en');
+                speakText = await Translate(message.cleanContent, { from: 'zh', to: 'en' });
             }
             catch (e) {
                 client.log(client.intlGet(null, 'infoCap'), `Translation failed: ${e.message}`);

--- a/src/discordTools/SetupSettingsMenu.js
+++ b/src/discordTools/SetupSettingsMenu.js
@@ -201,6 +201,23 @@ async function setupGeneralSettings(client, guildId, channel) {
     await client.messageSend(channel, {
         embeds: [DiscordEmbeds.getEmbed({
             color: Constants.COLOR_SETTINGS,
+            title: client.intlGet(guildId, 'teamChatVoiceSetting'),
+            thumbnail: `attachment://settings_logo.png`,
+            fields: [{
+                name: client.intlGet(guildId, 'steamId'),
+                value: instance.generalSettings.teamChatVoiceSteamId ?
+                    instance.generalSettings.teamChatVoiceSteamId : client.intlGet(guildId, 'none'),
+                inline: true
+            }]
+        })],
+        components: [DiscordButtons.getTeamChatVoiceButton(guildId)],
+        files: [new Discord.AttachmentBuilder(
+            Path.join(__dirname, '..', 'resources/images/settings_logo.png'))]
+    });
+
+    await client.messageSend(channel, {
+        embeds: [DiscordEmbeds.getEmbed({
+            color: Constants.COLOR_SETTINGS,
             title: client.intlGet(guildId, 'shouldLeaderCommandEnabledSetting'),
             thumbnail: `attachment://settings_logo.png`,
         })],

--- a/src/discordTools/discordButtons.js
+++ b/src/discordTools/discordButtons.js
@@ -385,6 +385,15 @@ module.exports = {
             }));
     },
 
+    getTeamChatVoiceButton: function (guildId) {
+        return new Discord.ActionRowBuilder().addComponents(
+            module.exports.getButton({
+                customId: 'TeamChatVoice',
+                label: Client.client.intlGet(guildId, 'editCap'),
+                style: PRIMARY
+            }));
+    },
+
     getLeaderCommandEnabledButton: function (guildId, enabled) {
         return new Discord.ActionRowBuilder().addComponents(
             module.exports.getButton({

--- a/src/discordTools/discordModals.js
+++ b/src/discordTools/discordModals.js
@@ -322,6 +322,25 @@ module.exports = {
         return modal;
     },
 
+    getTeamChatVoiceModal(guildId) {
+        const modal = module.exports.getModal({
+            customId: 'TeamChatVoice',
+            title: Client.client.intlGet(guildId, 'teamChatVoiceSetting')
+        });
+
+        modal.addComponents(
+            new Discord.ActionRowBuilder().addComponents(TextInput.getTextInput({
+                customId: 'TeamChatVoiceSteamId',
+                label: Client.client.intlGet(guildId, 'steamId'),
+                value: '',
+                style: Discord.TextInputStyle.Short,
+                required: false
+            }))
+        );
+
+        return modal;
+    },
+
     getTrackerRemovePlayerModal(guildId, trackerId) {
         const instance = Client.client.getInstance(guildId);
         const tracker = instance.trackers[trackerId];

--- a/src/discordTools/discordVoice.js
+++ b/src/discordTools/discordVoice.js
@@ -23,9 +23,9 @@ const Actors = require('../staticFiles/actors.json');
 const Client = require('../../index.ts');
 
 module.exports = {
-    sendDiscordVoiceMessage: async function (guildId, text) {
+    sendDiscordVoiceMessage: async function (guildId, text, altVoice = false) {
         const connection = getVoiceConnection(guildId);
-        const voice = await this.getVoice(guildId);
+        const voice = await this.getVoice(guildId, altVoice);
         const url = `https://api.streamelements.com/kappa/v2/speech?voice=${voice}&text=${encodeURIComponent(text)}`;
 
         if (connection) {
@@ -37,13 +37,17 @@ module.exports = {
         }
     },
 
-    getVoice: async function (guildId) {
+    getVoice: async function (guildId, altVoice = false) {
         const instance = Client.client.getInstance(guildId);
-        const gender = instance.generalSettings.voiceGender;
+        let gender = instance.generalSettings.voiceGender;
+        if (altVoice) {
+            gender = gender === 'male' ? 'female' : 'male';
+        }
         const language = instance.generalSettings.language;
 
         if (Actors[language]?.[gender] === null || Actors[language]?.[gender] === undefined) {
-            return Actors[language]?.[gender === 'male' ? 'female' : 'male'];
+            const fallbackGender = gender === 'male' ? 'female' : 'male';
+            return Actors[language]?.[fallbackGender];
         }
         else {
             return Actors[language]?.[gender];

--- a/src/handlers/buttonHandler.js
+++ b/src/handlers/buttonHandler.js
@@ -253,6 +253,10 @@ module.exports = async (client, interaction) => {
                 instance.generalSettings.smartSwitchNotifyInGameWhenChangedFromDiscord)]
         });
     }
+    else if (interaction.customId === 'TeamChatVoice') {
+        const modal = DiscordModals.getTeamChatVoiceModal(guildId);
+        await interaction.showModal(modal);
+    }
     else if (interaction.customId === 'LeaderCommandEnabled') {
         instance.generalSettings.leaderCommandEnabled = !instance.generalSettings.leaderCommandEnabled;
         client.setInstance(guildId, instance);

--- a/src/handlers/modalHandler.js
+++ b/src/handlers/modalHandler.js
@@ -29,6 +29,7 @@ const Scrape = require('../util/scrape.js');
 module.exports = async (client, interaction) => {
     const instance = client.getInstance(interaction.guildId);
     const guildId = interaction.guildId;
+    const rustplus = client.rustplusInstances[guildId];
 
     const verifyId = Math.floor(100000 + Math.random() * 900000);
     client.logInteraction(interaction, verifyId, 'userModal');
@@ -362,6 +363,19 @@ module.exports = async (client, interaction) => {
         }));
 
         await DiscordMessages.sendTrackerMessage(interaction.guildId, ids.trackerId);
+    }
+    else if (interaction.customId === 'TeamChatVoice') {
+        let steamId = interaction.fields.getTextInputValue('TeamChatVoiceSteamId').trim();
+        if (steamId === '') {
+            steamId = null;
+        }
+        instance.generalSettings.teamChatVoiceSteamId = steamId;
+        client.setInstance(guildId, instance);
+        if (rustplus) rustplus.generalSettings.teamChatVoiceSteamId = steamId;
+        client.log(client.intlGet(null, 'infoCap'), client.intlGet(null, 'modalValueChange', {
+            id: `${verifyId}`,
+            value: `${steamId}`
+        }));
     }
     else if (interaction.customId.startsWith('TrackerRemovePlayer')) {
         const ids = JSON.parse(interaction.customId.replace('TrackerRemovePlayer', ''));

--- a/src/handlers/teamChatHandler.js
+++ b/src/handlers/teamChatHandler.js
@@ -26,6 +26,6 @@ module.exports = async function (rustplus, client, message) {
     await DiscordMessages.sendTeamChatMessage(rustplus.guildId, message);
     if (instance.generalSettings.teamChatVoiceSteamId &&
         instance.generalSettings.teamChatVoiceSteamId === message.steamId.toString()) {
-        await DiscordVoice.sendDiscordVoiceMessage(rustplus.guildId, message.message);
+        await DiscordVoice.sendDiscordVoiceMessage(rustplus.guildId, message.message, true);
     }
 }

--- a/src/handlers/teamChatHandler.js
+++ b/src/handlers/teamChatHandler.js
@@ -19,7 +19,13 @@
 */
 
 const DiscordMessages = require('../discordTools/discordMessages.js');
+const DiscordVoice = require('../discordTools/discordVoice.js');
 
 module.exports = async function (rustplus, client, message) {
+    const instance = client.getInstance(rustplus.guildId);
     await DiscordMessages.sendTeamChatMessage(rustplus.guildId, message);
+    if (instance.generalSettings.teamChatVoiceSteamId &&
+        instance.generalSettings.teamChatVoiceSteamId === message.steamId.toString()) {
+        await DiscordVoice.sendDiscordVoiceMessage(rustplus.guildId, message.message);
+    }
 }

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -635,6 +635,7 @@
     "shouldSmartAlarmNotifyNotConnectedSetting": "Should Smart Alarms notify even if they are not setup on the connected rust server?",
     "shouldSmartAlarmsNotifyInGameSetting": "Should Smart Alarms notify In-Game?",
     "shouldSmartSwitchNotifyInGameWhenChangedFromDiscord": "Should Smart Switches and Smart Switch Groups notify In-Game when they are changed from discord?",
+    "teamChatVoiceSetting": "Set team chat voice Steam ID:",
     "showingBlacklist": "Showing the blacklist.",
     "showingSubscriptionList": "Showing the subscription list.",
     "shredder": "Shredder",

--- a/src/templates/generalSettingsTemplate.json
+++ b/src/templates/generalSettingsTemplate.json
@@ -22,5 +22,6 @@
     "battlemetricsTrackerNameChanges": true,
     "battlemetricsGlobalNameChanges": false,
     "battlemetricsGlobalLogin": false,
-    "battlemetricsGlobalLogout": false
+    "battlemetricsGlobalLogout": false,
+    "teamChatVoiceSteamId": null
 }


### PR DESCRIPTION
## Summary
- allow specifying a Steam ID whose in-game team chat messages are spoken in Discord voice
- expose new **Team chat voice Steam ID** setting with button and modal in settings page
- speak English translations of Chinese direct messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab44a9c350832098e7d8afba840e0d