### PR TITLE
Handle DM voice messages without active voice connection

### DIFF
--- a/src/discordEvents/directMessage.js
+++ b/src/discordEvents/directMessage.js
@@ -1,4 +1,6 @@
 const DiscordVoice = require('../discordTools/discordVoice.js');
+const DiscordMessages = require('../discordTools/discordMessages.js');
+const { getVoiceConnection } = require('@discordjs/voice');
 const Translate = require('translate');
 
 module.exports = {
@@ -25,7 +27,13 @@ module.exports = {
             const instance = client.getInstance(guildId);
             if (instance && instance.blacklist['discordIds'].includes(message.author.id)) continue;
 
-            await DiscordVoice.sendDiscordVoiceMessage(guildId, speakText, AltVoice);
+            const connection = getVoiceConnection(guildId);
+            if (connection) {
+                await DiscordVoice.sendDiscordVoiceMessage(guildId, speakText, AltVoice);
+            }
+            else {
+                await DiscordMessages.sendTTSMessage(guildId, message.author.username, speakText);
+            }
         }
 
         client.log(client.intlGet(null, 'infoCap'), client.intlGet(null, 'logDiscordMessage', {


### PR DESCRIPTION
## Summary
- send DM voice messages to team chat using TTS when bot isn't in a voice channel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2bcd53688320b4dc62c7774c2c4e