### PR TITLE
Add plugin system with example voice and alarm plugins

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -56,6 +56,10 @@ function createMissingDirectories() {
     if (!Fs.existsSync(Path.join(__dirname, 'maps'))) {
         Fs.mkdirSync(Path.join(__dirname, 'maps'));
     }
+
+    if (!Fs.existsSync(Path.join(__dirname, 'plugins'))) {
+        Fs.mkdirSync(Path.join(__dirname, 'plugins'));
+    }
 }
 
 process.on('unhandledRejection', error => {

--- a/plugins/dmVoice.js
+++ b/plugins/dmVoice.js
@@ -1,0 +1,18 @@
+const DiscordVoice = require('../src/discordTools/discordVoice.js');
+
+module.exports = {
+    name: 'dmVoice',
+    discord: {
+        messageCreate: async (client, message) => {
+            if (message.guild) return; // Only handle direct messages
+            if (message.author.bot) return;
+
+            for (const guild of client.guilds.cache.values()) {
+                const member = guild.members.cache.get(message.author.id);
+                if (member && member.voice && member.voice.channelId) {
+                    await DiscordVoice.sendDiscordVoiceMessage(guild.id, message.content);
+                }
+            }
+        }
+    }
+};

--- a/plugins/smartAlarmForward.js
+++ b/plugins/smartAlarmForward.js
@@ -1,0 +1,17 @@
+const DiscordTools = require('../src/discordTools/discordTools.js');
+
+// Replace with the ID of the channel that should receive smart alarm notifications
+const TARGET_CHANNEL_ID = 'REPLACE_ME';
+
+module.exports = {
+    name: 'smartAlarmForward',
+    rustplus: {
+        smartAlarm: async (rustplus, client, serverId, entityId) => {
+            const channel = DiscordTools.getTextChannelById(rustplus.guildId, TARGET_CHANNEL_ID);
+            if (!channel) return;
+            const instance = client.getInstance(rustplus.guildId);
+            const alarm = instance.serverList[serverId].alarms[entityId];
+            channel.send(`Alarm ${alarm.name} triggered on server ${serverId}`);
+        }
+    }
+};

--- a/src/discordEvents/messageCreate.js
+++ b/src/discordEvents/messageCreate.js
@@ -24,6 +24,7 @@ const DiscordTools = require('../discordTools/discordTools');
 module.exports = {
     name: 'messageCreate',
     async execute(client, message) {
+        if (!message.guild) return;
         const instance = client.getInstance(message.guild.id);
         const rustplus = client.rustplusInstances[message.guild.id];
 

--- a/src/rustplusEvents/message.js
+++ b/src/rustplusEvents/message.js
@@ -25,6 +25,7 @@ const InGameChatHandler = require('../handlers/inGameChatHandler.js');
 const SmartSwitchGroupHandler = require('../handlers/smartSwitchGroupHandler.js');
 const TeamChatHandler = require("../handlers/teamChatHandler.js");
 const TeamHandler = require('../handlers/teamHandler.js');
+const PluginManager = require('../util/pluginManager.js');
 
 module.exports = {
     name: 'message',
@@ -185,6 +186,7 @@ async function messageBroadcastEntityChangedSmartAlarm(rustplus, client, message
         server.alarms[entityId].lastTrigger = Math.floor(new Date() / 1000);
         client.setInstance(rustplus.guildId, instance);
         await DiscordMessages.sendSmartAlarmTriggerMessage(rustplus.guildId, serverId, entityId);
+        PluginManager.emitRustPlus('smartAlarm', rustplus, client, serverId, entityId);
 
         if (instance.generalSettings.smartAlarmNotifyInGame) {
             rustplus.sendInGameMessage(`${server.alarms[entityId].name}: ${server.alarms[entityId].message}`);

--- a/src/structures/DiscordBot.js
+++ b/src/structures/DiscordBot.js
@@ -34,6 +34,7 @@ const Logger = require('./Logger.js');
 const PermissionHandler = require('../handlers/permissionHandler.js');
 const RustLabs = require('../structures/RustLabs');
 const RustPlus = require('../structures/RustPlus');
+const PluginManager = require('../util/pluginManager.js');
 
 class DiscordBot extends Discord.Client {
     constructor(props) {
@@ -94,13 +95,22 @@ class DiscordBot extends Discord.Client {
             const event = require(`../discordEvents/${file}`);
 
             if (event.name === 'rateLimited') {
-                this.rest.on(event.name, (...args) => event.execute(this, ...args));
+                this.rest.on(event.name, (...args) => {
+                    event.execute(this, ...args);
+                    PluginManager.emitDiscord(event.name, this, ...args);
+                });
             }
             else if (event.once) {
-                this.once(event.name, (...args) => event.execute(this, ...args));
+                this.once(event.name, (...args) => {
+                    event.execute(this, ...args);
+                    PluginManager.emitDiscord(event.name, this, ...args);
+                });
             }
             else {
-                this.on(event.name, (...args) => event.execute(this, ...args));
+                this.on(event.name, (...args) => {
+                    event.execute(this, ...args);
+                    PluginManager.emitDiscord(event.name, this, ...args);
+                });
             }
         }
     }

--- a/src/structures/RustPlus.js
+++ b/src/structures/RustPlus.js
@@ -38,6 +38,7 @@ const Map = require('../util/map.js');
 const RustPlusLite = require('../structures/RustPlusLite');
 const TeamHandler = require('../handlers/teamHandler.js');
 const Timer = require('../util/timer.js');
+const PluginManager = require('../util/pluginManager.js');
 
 const TOKENS_LIMIT = 24;        /* Per player */
 const TOKENS_REPLENISH = 3;     /* Per second */
@@ -117,7 +118,10 @@ class RustPlus extends RustPlusLib {
             Path.join(__dirname, '..', 'rustplusEvents')).filter(file => file.endsWith('.js'));
         for (const file of eventFiles) {
             const event = require(`../rustplusEvents/${file}`);
-            this.on(event.name, (...args) => event.execute(this, Client.client, ...args));
+            this.on(event.name, (...args) => {
+                event.execute(this, Client.client, ...args);
+                PluginManager.emitRustPlus(event.name, this, Client.client, ...args);
+            });
         }
     }
 

--- a/src/util/pluginManager.js
+++ b/src/util/pluginManager.js
@@ -1,0 +1,54 @@
+const Fs = require('fs');
+const Path = require('path');
+
+class PluginManager {
+    constructor() {
+        this.plugins = [];
+        this.loadPlugins();
+    }
+
+    loadPlugins() {
+        const pluginDir = Path.join(__dirname, '..', '..', 'plugins');
+        if (!Fs.existsSync(pluginDir)) {
+            Fs.mkdirSync(pluginDir);
+            return;
+        }
+        const files = Fs.readdirSync(pluginDir).filter(f => f.endsWith('.js'));
+        for (const file of files) {
+            try {
+                const plugin = require(Path.join(pluginDir, file));
+                this.plugins.push(plugin);
+            } catch (err) {
+                console.error(`Failed to load plugin ${file}:`, err);
+            }
+        }
+    }
+
+    emitRustPlus(eventName, rustplus, client, ...args) {
+        for (const plugin of this.plugins) {
+            const handler = plugin.rustplus && plugin.rustplus[eventName];
+            if (typeof handler === 'function') {
+                try {
+                    handler(rustplus, client, ...args);
+                } catch (err) {
+                    console.error(`Plugin ${plugin.name || 'unknown'} rustplus ${eventName} error:`, err);
+                }
+            }
+        }
+    }
+
+    emitDiscord(eventName, client, ...args) {
+        for (const plugin of this.plugins) {
+            const handler = plugin.discord && plugin.discord[eventName];
+            if (typeof handler === 'function') {
+                try {
+                    handler(client, ...args);
+                } catch (err) {
+                    console.error(`Plugin ${plugin.name || 'unknown'} discord ${eventName} error:`, err);
+                }
+            }
+        }
+    }
+}
+
+module.exports = new PluginManager();


### PR DESCRIPTION
## Summary
- introduce plugin manager to load custom plugins and emit hooks for Discord and Rustplus events
- trigger plugin hooks for all events and smart alarm notifications
- add sample plugins for DM voice responses and redirecting smart alarm messages

## Testing
- `npm test` *(fails: Cannot find name 'require')*

------
https://chatgpt.com/codex/tasks/task_e_68aeb16f7d20832095f1a742ea391745