### PR TITLE
Add RU/EN in-game translation plugin with voice output

### DIFF
--- a/plugins/translate-bridge.js
+++ b/plugins/translate-bridge.js
@@ -1,0 +1,81 @@
+const Path = require('path');
+const Translate = require('translate');
+const DiscordVoice = require('../src/discordTools/discordVoice.js');
+
+const PLUGIN_NAME = Path.basename(__filename);
+
+function getSettings(client, guildId) {
+  const instance = client.getInstance(guildId);
+  if (!instance.pluginSettings) instance.pluginSettings = {};
+  if (!instance.pluginSettings[PLUGIN_NAME]) instance.pluginSettings[PLUGIN_NAME] = {};
+  return { instance, settings: instance.pluginSettings[PLUGIN_NAME] };
+}
+
+module.exports = {
+  defaultEnabled: true,
+  displayName: 'RU/EN Translate + Speak',
+  description: 'Adds !ru and !en in-game commands, translates message text, and speaks it in Discord voice if connected.',
+  configSchema: {
+    ruCommand: { type: 'text', label: 'Command for RU->EN (without prefix)', default: 'ru' },
+    enCommand: { type: 'text', label: 'Command for EN->RU (without prefix)', default: 'en' },
+    speakInVoice: { type: 'bool', label: 'Speak translated text in connected Discord voice channel', default: true }
+  },
+
+  onLoad: ({ client }) => {
+    client.log(client.intlGet(null, 'infoCap'), '[translate-bridge] loaded');
+  },
+
+  onInGameCommand: async ({ rustplus, client, command, caller }) => {
+    const guildId = rustplus.guildId;
+    const { settings } = getSettings(client, guildId);
+
+    const prefix = rustplus.generalSettings.prefix || '!';
+    const ruCommand = (settings.ruCommand || 'ru').trim().toLowerCase();
+    const enCommand = (settings.enCommand || 'en').trim().toLowerCase();
+
+    const trimmed = command.trim();
+    const lower = trimmed.toLowerCase();
+
+    let from = null;
+    let to = null;
+    let rawText = '';
+
+    if (lower.startsWith(`${prefix}${ruCommand} `)) {
+      from = 'ru';
+      to = 'en';
+      rawText = trimmed.slice(`${prefix}${ruCommand}`.length).trim();
+    }
+    else if (lower.startsWith(`${prefix}${enCommand} `)) {
+      from = 'en';
+      to = 'ru';
+      rawText = trimmed.slice(`${prefix}${enCommand}`.length).trim();
+    }
+    else {
+      return false;
+    }
+
+    if (!rawText) {
+      await rustplus.sendInGameMessage(`Usage: ${prefix}${from} <text>`);
+      return true;
+    }
+
+    try {
+      const translated = await Translate(rawText, { from, to });
+      const output = `${caller.name}: ${translated}`;
+
+      await rustplus.sendInGameMessage(output);
+
+      const speakInVoice = (typeof settings.speakInVoice === 'boolean') ? settings.speakInVoice : true;
+      if (speakInVoice) {
+        await DiscordVoice.sendDiscordVoiceMessage(guildId, translated);
+      }
+
+      return true;
+    }
+    catch (e) {
+      await rustplus.sendInGameMessage('Translation failed. Try again in a moment.');
+      client.log(client.intlGet(null, 'errorCap'), `[translate-bridge] ${e?.stack || e}`, 'error');
+      return true;
+    }
+  }
+};


### PR DESCRIPTION
### Motivation
- Provide simple in‑game translation commands to bridge Russian and English team chat and optionally speak the translated text in Discord voice.

### Description
- Add new plugin `plugins/translate-bridge.js` which adds in‑game commands (default `!ru` and `!en`) to translate text between Russian and English.
- The plugin exposes per‑guild settings via `configSchema` (`ruCommand`, `enCommand`, `speakInVoice`) and is `defaultEnabled: true` for new guilds.
- `onInGameCommand` parses the command, calls the `translate` library to translate the provided text, sends the translated message back to Rust team chat, and optionally calls `discordVoice.sendDiscordVoiceMessage` to speak the translated text in a connected Discord voice channel.
- Includes basic usage feedback for missing arguments and error handling that logs failures and notifies users with a friendly message.

### Testing
- Ran `git status --short` and committed the new file (`git commit`) which succeeded and added `plugins/translate-bridge.js` to the repo.
- Attempted to `require` the plugin with `node -e "require('./plugins/translate-bridge.js'); console.log('ok')"`, which failed with `MODULE_NOT_FOUND` because the `translate` dependency is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4076ed7808320a131946141290a04)